### PR TITLE
fix: reset `innerStart` variable if passed time is greater than `wait` ms

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -23,6 +23,7 @@ export function throttle<T extends unknown[]>(
   wait = 0,
   {start = true, middle = true, once = false}: ThrottleOptions = {}
 ): Throttler<T> {
+  let innerStart = start
   let last = 0
   let timer: ReturnType<typeof setTimeout>
   let cancelled = false
@@ -30,8 +31,13 @@ export function throttle<T extends unknown[]>(
     if (cancelled) return
     const delta = Date.now() - last
     last = Date.now()
-    if (start) {
-      start = false
+
+    if (start && middle && delta >= wait) {
+      innerStart = true
+    }
+
+    if (innerStart) {
+      innerStart = false
       callback.apply(this, args)
       if (once) fn.cancel()
     } else if ((middle && delta < wait) || !middle) {

--- a/test/index.ts
+++ b/test/index.ts
@@ -49,6 +49,17 @@ describe('throttle', () => {
     expect(calls).to.eql([[1], [3]])
   })
 
+  it('will fire even the passed time greater than `wait` ms', async () => {
+    fn(1)
+    await delay(200)
+    fn(2)
+    fn(3)
+    fn(4)
+    await delay(1000)
+    fn(5)
+    expect(calls).to.eql([[1], [2], [4], [5]])
+  })
+
   it('calls callback with given arguments (middle)', async () => {
     fn(1, 2, 3)
     fn(4, 5, 6)
@@ -129,6 +140,17 @@ describe('debounce (throttle with {start: false, middle: false})', () => {
     fn(3)
     await delay(100)
     expect(calls).to.eql([[3]])
+  })
+
+  it('will fire even the passed time greater than `wait` ms', async () => {
+    fn(1)
+    await delay(200)
+    fn(2)
+    fn(3)
+    fn(4)
+    await delay(1000)
+    fn(5)
+    expect(calls).to.eql([[1], [4]])
   })
 
   it('exposes `this`', async () => {


### PR DESCRIPTION
This PR will fix #12  issue.