### PR TITLE
Simplify npm publish step in workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,6 +24,4 @@ jobs:
       - run: npm version ${TAG_NAME} --git-tag-version=false
         env:
           TAG_NAME: ${{ github.event.release.tag_name }}
-      - run: npm whoami; npm --ignore-scripts publish --provenance
-        env:
-          NODE_AUTH_TOKEN: ${{secrets.npm_token}}
+      - run: npm --ignore-scripts publish --provenance


### PR DESCRIPTION
Part of: https://github.com/github/web-systems/issues/4309

OIDC migration. Removed npm whoami command from the publish workflow.